### PR TITLE
Encode function arguments before hashing them

### DIFF
--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -303,7 +303,7 @@ class SimpleCache(object):
 
     def get_hash(self, args):
         if self.hashkeys:
-            key = hashlib.md5(args).hexdigest()
+            key = hashlib.md5(args.encode('utf-8')).hexdigest()
         else:
             key = pickle.dumps(args)
         return key


### PR DESCRIPTION
Hashlib requires that any string passed to the md5 hash function be properly encoded beforehand. This patch does that, fixing the "TypeError: Unicode-objects must be encoded before hashing" that arises currently when decorating a function with @cache_it_json().

I'm not sure why this issue hasn't come up yet, but it was a problem on my end. Maybe hashlib was updated?